### PR TITLE
Fix signal.line in all plot modes & fix density/as.vector bugs

### DIFF
--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -373,8 +373,10 @@ CMplot <- function(
         x_max <- max(x, na.rm=TRUE)
         y_min <- min(y, na.rm=TRUE)
         y_max <- max(y, na.rm=TRUE)
-        x_scaled <- ceiling((x - x_min) / (x_max - x_min) * w * dpi / scale)
-        y_scaled <- ceiling((y - y_min) / (y_max - y_min) * h * dpi / scale)
+        x_range <- x_max - x_min
+        y_range <- y_max - y_min
+        if(x_range == 0) x_scaled <- rep(0L, length(x)) else x_scaled <- ceiling((x - x_min) / x_range * w * dpi / scale)
+        if(y_range == 0) y_scaled <- rep(0L, length(y)) else y_scaled <- ceiling((y - y_min) / y_range * h * dpi / scale)
         key <- x_scaled * 1000000L + y_scaled
         !duplicated(key)
     }

--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -1697,7 +1697,7 @@ CMplot <- function(
                     }
                 }
 
-                pvalue <- as.vector(Pmap[,3:(R+2)])
+                pvalue <- as.vector(unlist(Pmap[,3:(R+2)]))
                 if(is.null(ylim)){
                     if(!is.null(threshold)){
                         if(LOG10){

--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -869,8 +869,10 @@ CMplot <- function(
                     }
                 }
                 signal.line.index <- unique(signal.line.index)
+                if(!is.null(signal.line.index)){
+                    signal.line.index <- pvalue.posN[signal.line.index]
+                }
             }
-            signal.line.index <- pvalue.posN[signal.line.index]
         }
 
         if(file.output){
@@ -1454,6 +1456,24 @@ CMplot <- function(
                     if(file=="png") png(paste("Multi-tracks_Manhtn.",ifelse(is.null(file.name),taxa,file.name[1]),".png",sep=""), width=wh*dpi,height=ht*dpi*R,res=dpi,bg=NA)
                     par(mfcol=c(R,1), xaxs="i")
                 }
+                signal.line.index <- NULL
+                if(!is.null(threshold)){
+                    if(!is.null(signal.line)){
+                        for(l in 1:R){
+                            if(!is.null(threshold[[l]])){
+                                if(LOG10){
+                                    signal.line.index <- c(signal.line.index,which(pvalueT[,l] < min_no_na(threshold[[l]])))
+                                }else{
+                                    signal.line.index <- c(signal.line.index,which(pvalueT[,l] > max_no_na(threshold[[l]])))
+                                }
+                            }
+                        }
+                        signal.line.index <- unique(signal.line.index)
+                        if(!is.null(signal.line.index)){
+                            signal.line.index <- pvalue.posN[signal.line.index]
+                        }
+                    }
+                }
                 if(!file.output){
                     ht=ifelse(is.null(height), 6, height)
                     wh=ifelse(is.null(width), 14, width)
@@ -1633,7 +1653,9 @@ CMplot <- function(
                     }
                     if(!is.null(main) & R == 1)  title(main=main[1], cex.main=main.cex, font.main= main.font)
                     if(box) box(lwd=axis.lwd)
-                    #if(!is.null(threshold) & !is.null(signal.line))    abline(v=pvalue.posN[which(pvalueT[,i] < min_no_na(threshold))],col="grey",lty=2,lwd=signal.line)
+                    if(!is.null(threshold) & !is.null(signal.line) & !is.null(signal.line.index)){
+                        segments(signal.line.index, Min, signal.line.index, Max, col="grey", lty=2, lwd=signal.line)
+                    }
                 }
                 if(file.output) dev.off()
             }
@@ -1656,7 +1678,25 @@ CMplot <- function(
                     if(is.null(dev.list())) dev.new(width=wh, height=ht)
                     # par(xpd=TRUE)
                 }
-                
+                signal.line.index <- NULL
+                if(!is.null(threshold)){
+                    if(!is.null(signal.line)){
+                        for(l in 1:R){
+                            if(!is.null(threshold[[l]])){
+                                if(LOG10){
+                                    signal.line.index <- c(signal.line.index,which(pvalueT[,l] < min_no_na(threshold[[l]])))
+                                }else{
+                                    signal.line.index <- c(signal.line.index,which(pvalueT[,l] > max_no_na(threshold[[l]])))
+                                }
+                            }
+                        }
+                        signal.line.index <- unique(signal.line.index)
+                        if(!is.null(signal.line.index)){
+                            signal.line.index <- pvalue.posN[signal.line.index]
+                        }
+                    }
+                }
+
                 pvalue <- as.vector(Pmap[,3:(R+2)])
                 if(is.null(ylim)){
                     if(!is.null(threshold)){
@@ -1918,7 +1958,10 @@ CMplot <- function(
                         y.intersp=1,
                         x.intersp=1,
                         yjust=0.9, xjust=0, xpd=TRUE
-                    )          
+                    )
+                }
+                if(!is.null(threshold) & !is.null(signal.line) & !is.null(signal.line.index)){
+                    segments(signal.line.index, Min, signal.line.index, Max, col="grey", lty=2, lwd=signal.line)
                 }
                 if(!is.null(main))  title(main=main[1], cex.main=main.cex, font.main= main.font)
                 if(box) box(lwd=axis.lwd)
@@ -2143,7 +2186,18 @@ CMplot <- function(
                         }
                     }
 
-                    #if(!is.null(threshold) & !is.null(signal.line))    abline(v=pvalue.posN[which(pvalueT[,i] < min_no_na(threshold))],col="grey",lty=2,lwd=signal.line)
+                    if(!is.null(threshold) & !is.null(signal.line)){
+                        if(!is.null(threshold[[i]])){
+                            if(LOG10){
+                                idx <- which(pvalueT[,i] < min_no_na(threshold[[i]]))
+                            }else{
+                                idx <- which(pvalueT[,i] > max_no_na(threshold[[i]]))
+                            }
+                            if(length(idx) > 0){
+                                segments(pvalue.posN[idx], Min, pvalue.posN[idx], Max, col="grey", lty=2, lwd=signal.line)
+                            }
+                        }
+                    }
             
                     if(is.null(ylim)){ymin <- Min}else{ymin <- min_no_na(ylim[[i]])}
                     if(cir.density){


### PR DESCRIPTION
## Summary

3 bug fixes:

### 1. Fix division-by-zero in `filter.points` causing density plot point loss

`filter.points` is called with constant y values in density rendering (`plot.type="d"` and chromosome density bar). When `y_range == 0`, the original code `(y - y_min) / (y_max - y_min)` produces `0/0 = NaN`. R's `duplicated()` treats all-but-first `NaN` as duplicates, so the entire density bar collapses to a single pixel.

### 2. Fix `signal.line` rendering across all Manhattan plot modes

Before this fix, `signal.line` (vertical emphasis lines at significant SNP positions) was broken in most modes:

| Mode | Before | After |
|------|--------|-------|
| Circular | Had implementation but `pvalue.posN[NULL]` unsafe | Added null guard |
| Multi-tracks | Not implemented at all | Full implementation |
| Multi-traits | Not implemented at all | Full implementation |
| Single-trait | Code was commented out | Uncommented and fixed |

All modes now use `segments()` instead of `abline()` for reliable multi-panel rendering, with proper `LOG10` handling and per-trait threshold logic.

### 3. Fix `as.vector` bug causing multi-traits mode to crash

`as.vector(Pmap[,3:(R+2)])` does not flatten a multi-column data.frame to a numeric vector, causing `min()` to fail with "invalid type (list)". Fixed by using `unlist()` first. Bug existed since upstream (2023-06-28).

## Test plan

- [x] Multi-tracks Manhattan with `signal.line` — verified with pig60K test data
- [x] Single-trait Manhattan with `signal.line` — verified
- [x] Circular Manhattan with `signal.line` — verified  
- [x] Multi-traits Manhattan — no longer crashes, `signal.line` works
- [x] Density plot (`plot.type="d"`) — no longer loses points
- [x] Q-Q plot — no regression
- [x] No regression on existing functionality