### PR TITLE
Fix division-by-zero in filter.points & as.vector regression in multi-traits

### DIFF
--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -373,8 +373,10 @@ CMplot <- function(
         x_max <- max(x, na.rm=TRUE)
         y_min <- min(y, na.rm=TRUE)
         y_max <- max(y, na.rm=TRUE)
-        x_scaled <- ceiling((x - x_min) / (x_max - x_min) * w * dpi / scale)
-        y_scaled <- ceiling((y - y_min) / (y_max - y_min) * h * dpi / scale)
+        x_range <- x_max - x_min
+        y_range <- y_max - y_min
+        if(x_range == 0) x_scaled <- rep(0L, length(x)) else x_scaled <- ceiling((x - x_min) / x_range * w * dpi / scale)
+        if(y_range == 0) y_scaled <- rep(0L, length(y)) else y_scaled <- ceiling((y - y_min) / y_range * h * dpi / scale)
         key <- x_scaled * 1000000L + y_scaled
         !duplicated(key)
     }

--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -1657,7 +1657,7 @@ CMplot <- function(
                     # par(xpd=TRUE)
                 }
                 
-                pvalue <- as.vector(Pmap[,3:(R+2)])
+                pvalue <- as.vector(unlist(Pmap[,3:(R+2)]))
                 if(is.null(ylim)){
                     if(!is.null(threshold)){
                         if(LOG10){


### PR DESCRIPTION
## Summary

### 1. Fix division-by-zero in `filter.points` causing density plot point loss

`filter.points` is called with constant y values in density rendering. When `y_range == 0`, `(y - y_min) / (y_max - y_min)` produces `0/0 = NaN`. R's `duplicated()` treats the first `NaN` as unique and all subsequent as duplicates, collapsing the entire density bar to a single pixel.

**Reproduce:**
```r
data(pig60K)
CMplot(pig60K, plot.type="d", bin.size=1e6,
       chr.den.col=c("darkgreen", "yellow", "red"),
       file="jpg", dpi=300, file.output=TRUE)
```

### 2. Fix `as.vector` regression in multi-traits mode

The optimization commit (23905fc) removed `Pmap <- as.matrix(Pmap)` to keep Pmap as data.frame for performance. However, `as.vector(Pmap[,3:(R+2)])` in the multi-traits section relies on Pmap being a matrix — `as.vector()` on a data.frame (which is a list) returns it unchanged. Subsequent `min_no_na(pvalue)` → `min(list, na.rm=TRUE)` crashes.

**Reproduce:**
```r
data(pig60K)
CMplot(pig60K, plot.type="m", LOG10=TRUE, multraits=TRUE,
       col=c("grey60","#4197d8","#f8c120"),
       file="jpg", dpi=150, file.output=TRUE)
# Error: invalid 'type' (list) of argument
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)